### PR TITLE
Test enhancment for PHPUnit fixtures and version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
     "description": "Allows mocking otherwise untestable PHP functions through the use of namespaces",
     "license": "MIT",
     "require": {
-        "php": "~7"
+        "php": "~7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6"
+        "phpunit/phpunit": "~7"
     },
     "authors": [
         {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,9 +3,7 @@
          convertErrorsToExceptions="true"
          convertWarningsToExceptions="true"
          convertNoticesToExceptions="true"
-         mapTestClassNameToCoveredClassName="true"
          bootstrap="vendor/autoload.php"
-         strict="true"
          verbose="true"
          colors="true">
 
@@ -16,18 +14,14 @@
     </testsuites>
 
     <logging>
-        <log type="coverage-html" target="build/coverage" title="ExceptionBundle"
-             charset="UTF-8" yui="true" highlight="true"
-             lowUpperBound="35" highLowerBound="70"/>
+        <log type="coverage-html" target="build/coverage" lowUpperBound="35" highLowerBound="70"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
-        <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
+        <log type="junit" target="build/logs/junit.xml"/>
     </logging>
 
     <filter>
-        <blacklist>
-            <directory suffix=".php">tests/</directory>
-            <directory suffix=".php">vendor/</directory>
-            <directory suffix=".php">/usr/share/php</directory>
-        </blacklist>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
     </filter>
 </phpunit>

--- a/tests/PHPUnitTests/Extension/FunctionMockerTest.php
+++ b/tests/PHPUnitTests/Extension/FunctionMockerTest.php
@@ -11,12 +11,12 @@ class FunctionMockerTest extends TestCase
     /** @var FunctionMocker */
     private $functionMocker;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->functionMocker = FunctionMocker::start($this, 'My\TestNamespace');
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         FunctionMocker::tearDown();
     }

--- a/tests/PHPUnitTests/Extension/IntegrationTest.php
+++ b/tests/PHPUnitTests/Extension/IntegrationTest.php
@@ -10,7 +10,7 @@ class IntegrationTest extends TestCase
 {
     private $php;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->php = FunctionMocker::start($this, 'PHPUnitTests\Extension\Fixtures')
             ->mockFunction('strpos')


### PR DESCRIPTION
# Changed log

- It seems that the package requires `php-7.1` version at least. Setting the correct version semver for `PHP`.
- Removing some invalid attributes on `phpunit.xml.dist` file.

These invalid attribute messages are as follows:

```
Line 10:
  - Element 'phpunit', attribute 'mapTestClassNameToCoveredClassName': The attribute 'mapTestClassNameToCoveredClassName' is not allowed.
  - Element 'phpunit', attribute 'strict': The attribute 'strict' is not allowed.

  Line 21:
  - Element 'log', attribute 'title': The attribute 'title' is not allowed.
  - Element 'log', attribute 'charset': The attribute 'charset' is not allowed.
  - Element 'log', attribute 'yui': The attribute 'yui' is not allowed.
  - Element 'log', attribute 'highlight': The attribute 'highlight' is not allowed.

  Line 23:
  - Element 'log', attribute 'logIncompleteSkipped': The attribute 'logIncompleteSkipped' is not allowed.

  Line 27:
  - Element 'blacklist': This element is not expected. Expected is ( whitelist ).
```
- According to the [official PHPUnit doc](https://phpunit.readthedocs.io/en/7.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp(): void` and `protected function tearDown(): void`.